### PR TITLE
fix database id int usage and make analysis table use image upload table

### DIFF
--- a/backend/app/src/middleware/auth.middleware.ts
+++ b/backend/app/src/middleware/auth.middleware.ts
@@ -2,7 +2,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { jwtService } from '../services/index.js';
 
 export interface JwtPayload {
-  userId: number;
+  userId: string;
   email: string;
   timestamp: number;
   iat: number;

--- a/backend/app/src/routes/ingredients.routes.ts
+++ b/backend/app/src/routes/ingredients.routes.ts
@@ -12,25 +12,15 @@ import { parseMultipartWithPrompt } from '../utils/route.utils.js';
 const ROOT_ROUTE = 'ingredients';
 
 interface CommitBody {
-  analysisId: number;
+  analysisId: string;
   overrides?: {
     mealTitle?: string;
     mealDescription?: string;
   };
 }
-
 interface DeclineBody {
-  analysisId: number;
+  analysisId: string;
   reason?: string;
-}
-
-interface ReanalyzeBody {
-  analysisId: number;
-  userEdits: {
-    mealTitle?: string;
-    mealDescription?: string;
-    additionalContext?: string;
-  };
 }
 
 export const ingridientRouts = async (fastify: FastifyInstance) => {
@@ -49,7 +39,7 @@ export const ingridientRouts = async (fastify: FastifyInstance) => {
     { preHandler: authenticate },
     async (request, reply) => {
       const startTime = Date.now();
-      let analysisId: number | null = null;
+      let analysisId: string | null = null;
 
       try {
         // Step 1: Get file and prompt from multipart request
@@ -203,150 +193,6 @@ export const ingridientRouts = async (fastify: FastifyInstance) => {
     }
   );
 
-  // TODO: uncomment if we come back to this feature
-  // /**
-  //  * POST /ingredients/reanalyze
-  //  * Re-analyze with user-provided hints/corrections
-  //  */
-  // fastify.post<{ Body: ReanalyzeBody }>(
-  //   `/${ROOT_ROUTE}/reanalyze`,
-  //   { preHandler: authenticate },
-  //   async (request, reply) => {
-  //     const startTime = Date.now();
-
-  //     try {
-  //       const { analysisId, userEdits } = request.body;
-
-  //       if (!analysisId) {
-  //         return reply.code(400).send({ error: 'analysisId is required' });
-  //       }
-
-  //       // Get existing analysis
-  //       const analysis = await prisma.ingredientAnalysis.findUnique({
-  //         where: { id: analysisId },
-  //       });
-
-  //       if (!analysis) {
-  //         return reply.code(404).send({ error: 'Analysis not found' });
-  //       }
-
-  //       if (analysis.status !== AnalysisStatus.COMPLETED) {
-  //         return reply.code(400).send({
-  //           error: `Cannot reanalyze with status: ${analysis.status}`,
-  //         });
-  //       }
-
-  //       // Verify user owns this analysis
-  //       if (analysis.userId !== request.user.userId) {
-  //         return reply.code(403).send({ error: 'Access denied' });
-  //       }
-
-  //       // Get compressed image from S3
-  //       if (!analysis.compressedFileKey) {
-  //         return reply.code(400).send({
-  //           error: 'No compressed image available for reanalysis',
-  //         });
-  //       }
-
-  //       const tempKey = `temp/${analysis.compressedFileKey}`;
-  //       const imageData = await s3Service.retrieve(tempKey);
-
-  //       if (!imageData) {
-  //         return reply.code(404).send({
-  //           error: 'Image file not found. It may have expired.',
-  //         });
-  //       }
-
-  //       // Convert stream to buffer
-  //       const chunks: Buffer[] = [];
-  //       for await (const chunk of imageData.stream) {
-  //         chunks.push(Buffer.from(chunk));
-  //       }
-  //       const imageBuffer = Buffer.concat(chunks);
-
-  //       // Update status to ANALYZING
-  //       await prisma.ingredientAnalysis.update({
-  //         where: { id: analysisId },
-  //         data: {
-  //           status: AnalysisStatus.ANALYZING,
-  //           analyzedAt: new Date(),
-  //         },
-  //       });
-
-  //       // Call LLM with hints
-  //       const llmResponse = await llmService.analyzeImage({
-  //         imageBuffer,
-  //         imageMimeType: imageData.contentType,
-  //         hints: {
-  //           mealTitle: userEdits.mealTitle,
-  //           mealDescription: userEdits.mealDescription,
-  //           additionalContext: userEdits.additionalContext,
-  //         },
-  //       });
-
-  //       // Validate that image contains food
-  //       if (!llmResponse.isFood) {
-  //         throw new NonFoodImageError(llmResponse.detectedContent);
-  //       }
-
-  //       // Update analysis with new LLM results
-  //       const totalCalories = llmResponse.nutritionFacts?.calories || null;
-  //       const totalSugar = llmResponse.nutritionFacts?.totalSugars || null;
-  //       const totalCarbs = llmResponse.nutritionFacts?.totalCarbs || null;
-  //       const totalProtein = llmResponse.nutritionFacts?.protein || null;
-
-  //       await prisma.ingredientAnalysis.update({
-  //         where: { id: analysisId },
-  //         data: {
-  //           analysisData: llmResponse as object,
-  //           mealTitle: llmResponse.mealTitle,
-  //           mealDescription: llmResponse.mealDescription,
-  //           totalCalories,
-  //           totalSugar,
-  //           totalCarbs,
-  //           totalProtein,
-  //           status: AnalysisStatus.COMPLETED,
-  //         },
-  //       });
-
-  //       const processingTime = Date.now() - startTime;
-
-  //       return reply.code(200).send({
-  //         success: true,
-  //         analysisId,
-  //         provider: llmService.getProviderName(),
-  //         processingTimeMs: processingTime,
-  //         analysis: {
-  //           mealTitle: llmResponse.mealTitle,
-  //           mealDescription: llmResponse.mealDescription,
-  //           ingredients: llmResponse.ingredients,
-  //           nutritionFacts: llmResponse.nutritionFacts,
-  //           allergens: llmResponse.allergens,
-  //           healthFlags: llmResponse.healthFlags,
-  //           confidence: llmResponse.confidence,
-  //         },
-  //         message: 'Reanalysis complete. Review and commit or decline.',
-  //       });
-  //     } catch (error) {
-  //       fastify.log.error(error);
-
-  //       // Handle non-food image error with specific response
-  //       if (error instanceof NonFoodImageError) {
-  //         return reply.code(400).send({
-  //           error: 'Not a food image',
-  //           message: 'The uploaded image does not appear to contain food.',
-  //           detectedContent: error.detectedContent,
-  //         });
-  //       }
-
-  //       return reply.code(500).send({
-  //         error: 'Reanalysis failed',
-  //         message: error instanceof Error ? error.message : 'Unknown error',
-  //       });
-  //     }
-  //   }
-  // );
-
   /**
    * POST /ingredients/commit
    * User validates results - save to DB, delete temp images
@@ -492,12 +338,7 @@ export const ingridientRouts = async (fastify: FastifyInstance) => {
     { preHandler: authenticate },
     async (request, reply) => {
       try {
-        const analysisId = parseInt(request.params.analysisId);
-
-        if (isNaN(analysisId)) {
-          return reply.code(400).send({ error: 'Invalid analysisId' });
-        }
-
+        const { analysisId } = request.params;
         const analysis = await prisma.ingredientAnalysis.findUnique({
           where: { id: analysisId },
         });

--- a/backend/app/src/services/jwt.service.ts
+++ b/backend/app/src/services/jwt.service.ts
@@ -7,7 +7,7 @@ class JwtService {
    * Generate a JWT token for authenticated user
    */
   generateToken(payload: {
-    userId: number;
+    userId: string;
     email: string;
     timestamp: EpochTimeStamp;
   }) {

--- a/backend/prisma/migrations/20260123154623/migration.sql
+++ b/backend/prisma/migrations/20260123154623/migration.sql
@@ -1,0 +1,44 @@
+/*
+  Warnings:
+
+  - The primary key for the `ingredient_analyses` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `users` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "file_uploads" DROP CONSTRAINT "file_uploads_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ingredient_analyses" DROP CONSTRAINT "ingredient_analyses_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "file_uploads" ALTER COLUMN "user_id" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "ingredient_analyses" DROP CONSTRAINT "ingredient_analyses_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "user_id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "ingredient_analyses_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "ingredient_analyses_id_seq";
+
+-- AlterTable
+ALTER TABLE "users" DROP CONSTRAINT "users_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "users_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "users_id_seq";
+
+-- AlterTable
+ALTER TABLE "file_uploads" DROP CONSTRAINT "file_uploads_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "file_uploads_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "file_uploads_id_seq";
+
+
+-- AddForeignKey
+ALTER TABLE "file_uploads" ADD CONSTRAINT "file_uploads_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ingredient_analyses" ADD CONSTRAINT "ingredient_analyses_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260123163505/migration.sql
+++ b/backend/prisma/migrations/20260123163505/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `compressed_file_key` on the `ingredient_analyses` table. All the data in the column will be lost.
+  - You are about to drop the column `file_key` on the `ingredient_analyses` table. All the data in the column will be lost.
+  - You are about to drop the `file_uploads` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "file_uploads" DROP CONSTRAINT "file_uploads_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "ingredient_analyses" DROP COLUMN "compressed_file_key",
+DROP COLUMN "file_key";
+
+-- DropTable
+DROP TABLE "file_uploads";
+
+-- CreateTable
+CREATE TABLE "image_uploads" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "analysis_id" TEXT NOT NULL,
+    "type" "FileType" NOT NULL,
+    "file_key" TEXT NOT NULL,
+    "compressed_file_key" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "image_uploads_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "image_uploads_analysis_id_idx" ON "image_uploads"("analysis_id");
+
+-- AddForeignKey
+ALTER TABLE "image_uploads" ADD CONSTRAINT "image_uploads_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "image_uploads" ADD CONSTRAINT "image_uploads_analysis_id_fkey" FOREIGN KEY ("analysis_id") REFERENCES "ingredient_analyses"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema/schema.prisma
+++ b/backend/prisma/schema/schema.prisma
@@ -28,8 +28,8 @@ enum AnalysisStatus {
 }
 
 model FileUpload {
-    id       Int      @id @default(autoincrement())
-    userId   Int      @map("user_id")
+    id       String   @id @default(uuid())
+    userId   String   @map("user_id")
     type     FileType
     filePath String   @map("file_path")
     user     User?    @relation(fields: [userId], references: [id])
@@ -39,8 +39,8 @@ model FileUpload {
 }
 
 model IngredientAnalysis {
-    id                Int            @id @default(autoincrement())
-    userId            Int            @map("user_id")
+    id                String         @id @default(uuid())
+    userId            String         @map("user_id")
     fileKey           String         @map("file_key")
     compressedFileKey String?        @map("compressed_file_key")
     status            AnalysisStatus @default(PENDING)
@@ -52,10 +52,10 @@ model IngredientAnalysis {
     // Extracted searchable fields (for pre-filtering before sending to LLM)
     mealTitle       String?  @map("meal_title")
     mealDescription String?  @map("meal_description")
-    totalCalories Decimal? @map("total_calories") @db.Decimal(10, 2)
-    totalSugar    Decimal? @map("total_sugar") @db.Decimal(10, 2)
-    totalCarbs    Decimal? @map("total_carbs") @db.Decimal(10, 2)
-    totalProtein  Decimal? @map("total_protein") @db.Decimal(10, 2)
+    totalCalories   Decimal? @map("total_calories") @db.Decimal(10, 2)
+    totalSugar      Decimal? @map("total_sugar") @db.Decimal(10, 2)
+    totalCarbs      Decimal? @map("total_carbs") @db.Decimal(10, 2)
+    totalProtein    Decimal? @map("total_protein") @db.Decimal(10, 2)
 
     createdAt   DateTime  @default(now()) @map("created_at")
     analyzedAt  DateTime? @map("analyzed_at")
@@ -70,7 +70,7 @@ model IngredientAnalysis {
 }
 
 model User {
-    id                 Int                  @id @default(autoincrement())
+    id                 String               @id @default(uuid())
     email              String               @unique
     password           String
     fileUploads        FileUpload[]

--- a/backend/prisma/schema/schema.prisma
+++ b/backend/prisma/schema/schema.prisma
@@ -27,23 +27,26 @@ enum AnalysisStatus {
     @@schema("app")
 }
 
-model FileUpload {
-    id       String   @id @default(uuid())
-    userId   String   @map("user_id")
-    type     FileType
-    filePath String   @map("file_path")
-    user     User?    @relation(fields: [userId], references: [id])
+model ImageUpload {
+    id                String             @id @default(uuid())
+    userId            String             @map("user_id")
+    analysisId        String             @map("analysis_id")
+    type              FileType
+    fileKey           String             @map("file_key")
+    compressedFileKey String?            @map("compressed_file_key")
+    createdAt         DateTime           @default(now()) @map("created_at")
+    user              User               @relation(fields: [userId], references: [id])
+    analysis          IngredientAnalysis @relation(fields: [analysisId], references: [id])
 
-    @@map("file_uploads")
+    @@index([analysisId])
+    @@map("image_uploads")
     @@schema("app")
 }
 
 model IngredientAnalysis {
-    id                String         @id @default(uuid())
-    userId            String         @map("user_id")
-    fileKey           String         @map("file_key")
-    compressedFileKey String?        @map("compressed_file_key")
-    status            AnalysisStatus @default(PENDING)
+    id     String         @id @default(uuid())
+    userId String         @map("user_id")
+    status AnalysisStatus @default(PENDING)
 
     // Full LLM response as JSON - source of truth for LLM queries
     // Contains: mealTitle, mealDescription, ingredients[], nutritionFacts{}, allergens[], healthFlags[]
@@ -61,7 +64,8 @@ model IngredientAnalysis {
     analyzedAt  DateTime? @map("analyzed_at")
     committedAt DateTime? @map("committed_at")
 
-    user User @relation(fields: [userId], references: [id])
+    user   User          @relation(fields: [userId], references: [id])
+    images ImageUpload[]
 
     @@index([userId, analyzedAt])
     @@index([userId, status])
@@ -73,7 +77,7 @@ model User {
     id                 String               @id @default(uuid())
     email              String               @unique
     password           String
-    fileUploads        FileUpload[]
+    analysisImages     ImageUpload[]
     ingredientAnalyses IngredientAnalysis[]
 
     @@map("users")


### PR DESCRIPTION
This removes an accidental use of INTs as database IDs and also splits analysis table from images it references.

I want to be able to support multiple images in the future if I need to, and this will be much easier done if we store images in a separate table.

Since we have 2 db calls they are now wrapped in a prisma transaction block.

This also drops image deletes from s3 bucket once image parsing is complete - we might need images in the future.